### PR TITLE
2 add pubchem

### DIFF
--- a/libs/Annotator.py
+++ b/libs/Annotator.py
@@ -1,6 +1,7 @@
 from libs.services.CIR import CIR
 from libs.services.CTS import CTS
 from libs.services.NLM import NLM
+from libs.services.PubChem import PubChem
 
 
 class Annotator:
@@ -9,6 +10,7 @@ class Annotator:
         self.CTS = CTS()
         self.CIR = CIR()
         self.NLM = NLM()
+        self.PubChem = PubChem()
 
     def add_possible_annotations(self, metadata):
         """
@@ -70,13 +72,15 @@ class Annotator:
         - CTS service based chemical name
         - NLM service based chemical name
         - CIR service based on SMILES
+        - PubChem service based on InChi
 
         :param metadata: specified metadata dictionary
         :return: found InChiKey (return None if not found)
         """
         conversions = {'casno': [self.CTS.cas_to_inchikey],
                        'name': [self.CTS.name_to_inchikey, self.NLM.name_to_inchikey],
-                       'smiles': [self.CIR.smiles_to_inchikey]}
+                       'smiles': [self.CIR.smiles_to_inchikey],
+                       'inchi': [self.PubChem.inchi_to_inchikey]}
         return self.execute_conversions(conversions, metadata)
 
     def add_smiles(self, metadata):
@@ -86,12 +90,14 @@ class Annotator:
         Currently implemented strategies:
         - CIR service based on CAS number
         - CIR service based on InChiKey
+        - PubChem service based on InChi
 
         :param metadata: specified metadata dictionary
         :return: found SMILES (return None if not found)
         """
         conversions = {'casno': [self.CIR.cas_to_smiles],
-                       'inchikey': [self.CIR.inchikey_to_smiles]}
+                       'inchikey': [self.CIR.inchikey_to_smiles],
+                       'inchi': [self.PubChem.inchi_to_smiles]}
         return self.execute_conversions(conversions, metadata)
 
     def add_inchi(self, metadata):
@@ -101,11 +107,13 @@ class Annotator:
         Currently implemented strategies:
         - CTS compound service based on CAS InChiKey
         - CIR service based on CAS InChiKey
+        - PubChem service based on chemical name
 
         :param metadata: specified metadata dictionary
         :return: found InChi (return None if not found)
         """
-        conversions = {'inchikey': [self.CTS.inchikey_to_inchi, self.CIR.inchikey_to_inchi]}
+        conversions = {'inchikey': [self.CTS.inchikey_to_inchi, self.CIR.inchikey_to_inchi],
+                       'name': [self.PubChem.name_to_inchi]}
         return self.execute_conversions(conversions, metadata)
 
     def add_name(self, metadata):
@@ -128,9 +136,25 @@ class Annotator:
 
         Currently implemented strategies:
         - CTS service based on InChiKey
+        - NLM service based on InChiKey
+        - PubChem service based on InChi
 
         :param metadata: specified metadata dictionary
         :return: found IUPAC name (return None if not found)
         """
-        conversions = {'inchikey': [self.CTS.inchikey_to_IUPAC_name, self.NLM.inchikey_to_name]}
+        conversions = {'inchikey': [self.CTS.inchikey_to_IUPAC_name, self.NLM.inchikey_to_name],
+                       'inchi': [self.PubChem.inchi_to_IUPAC_name]}
+        return self.execute_conversions(conversions, metadata)
+
+    def add_formula(self, metadata):
+        """
+        Tries to find chemical formula name based on specified metadata.
+
+        Currently implemented strategies:
+        - PubChem service based on InChi
+
+        :param metadata: specified metadata dictionary
+        :return: found chemical formula (return None if not found)
+        """
+        conversions = {'inchi': [self.PubChem.inchi_to_formula]}
         return self.execute_conversions(conversions, metadata)

--- a/libs/services/CIR.py
+++ b/libs/services/CIR.py
@@ -44,7 +44,7 @@ class CIR(Converter):
         args = '{}/stdinchi'.format(inchikey)
         response = self.connect_to_service('CIR', args)
         if response.status_code == 200:
-            return response.text[6:]
+            return response.text
 
     def inchikey_to_cas(self, inchikey):
         """

--- a/libs/services/CTS.py
+++ b/libs/services/CTS.py
@@ -35,7 +35,7 @@ class CTS(Converter):
         args = inchikey
         response = self.connect_to_service('CTS_compound', args)
         if response.status_code == 200:
-            return response.json()["inchicode"][6:]
+            return response.json()["inchicode"]
 
     def name_to_inchikey(self, name):
         """

--- a/libs/services/Converter.py
+++ b/libs/services/Converter.py
@@ -7,22 +7,37 @@ class Converter:
         # the same query multiple times in single session
         self.cache = dict()
 
-    def connect_to_service(self, service, args):
+    def connect_to_service(self, service, args, method='GET'):
         """
         Make get request to given service with arguments.
         Raises ConnectionError if service is not available.
 
         :param service: requested service to be queried
         :param args: additional query arguments
+        :param method: GET (default) or POST
         :return: obtained response
         """
         try:
-            identification = service + ":" + args
+            identification = service + ":" + str(args)
             cached_result = self.cache.get(identification, None)
             if cached_result:
                 return cached_result
-            result = requests.get(self.services[service] + args)
+            result = self.execute_request(self.services[service], args, method)
             self.cache[identification] = result
             return result
         except requests.exceptions.ConnectionError:
             raise ConnectionError('Service {} is not available'.format(service))
+
+    def execute_request(self, url, args, method):
+        """
+        Execute request with type depending on specified method.
+
+        :param url: service URL
+        :param args: given args - either url args for GET or dict for POST
+        :param method: GET/POST
+        :return: obtained response
+        """
+        if method == 'GET':
+            return requests.get(url + args)
+        else:
+            return requests.post(url, data=args)

--- a/libs/services/Converter.py
+++ b/libs/services/Converter.py
@@ -7,7 +7,7 @@ class Converter:
         # the same query multiple times in single session
         self.cache = dict()
 
-    def connect_to_service(self, service, args, method='GET'):
+    def connect_to_service(self, service, args, method='GET', data=None):
         """
         Make get request to given service with arguments.
         Raises ConnectionError if service is not available.
@@ -15,29 +15,30 @@ class Converter:
         :param service: requested service to be queried
         :param args: additional query arguments
         :param method: GET (default) or POST
+        :param data: data for POST request
         :return: obtained response
         """
         try:
-            identification = service + ":" + str(args)
+            identification = service + ":" + args
             cached_result = self.cache.get(identification, None)
             if cached_result:
                 return cached_result
-            result = self.execute_request(self.services[service], args, method)
+            result = self.execute_request(self.services[service] + args, method, data)
             self.cache[identification] = result
             return result
         except requests.exceptions.ConnectionError:
             raise ConnectionError('Service {} is not available'.format(service))
 
-    def execute_request(self, url, args, method):
+    def execute_request(self, url, method, data=None):
         """
         Execute request with type depending on specified method.
 
         :param url: service URL
-        :param args: given args - either url args for GET or dict for POST
         :param method: GET/POST
+        :param data: given arguments for POST request
         :return: obtained response
         """
         if method == 'GET':
-            return requests.get(url + args)
+            return requests.get(url)
         else:
-            return requests.post(url, data=args)
+            return requests.post(url, data=data)

--- a/libs/services/Converter.py
+++ b/libs/services/Converter.py
@@ -27,7 +27,7 @@ class Converter:
             self.cache[identification] = result
             return result
         except requests.exceptions.ConnectionError:
-            raise ConnectionError('Service {} is not available'.format(service))
+            raise ConnectionError(f'Service {service} is not available')
 
     def execute_request(self, url, method, data=None):
         """

--- a/libs/services/PubChem.py
+++ b/libs/services/PubChem.py
@@ -1,0 +1,48 @@
+from libs.services.Converter import Converter
+
+
+class PubChem(Converter):
+    def __init__(self):
+        super().__init__()
+        # service URLs
+        self.services = {'PubChem': 'https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/'}
+
+    def inchi_to_inchikey(self, inchi):
+        args = "inchi/JSON"
+        response = self.connect_to_service('PubChem', args, method='POST', data={'inchi': inchi})
+        if response.status_code == 200:
+            for prop in response.json()['PC_Compounds'][0]['props']:
+                if prop['urn']['label'] == 'InChIKey':
+                    return prop['value']['sval']
+
+    def name_to_inchi(self, name):
+        args = 'name/{}/JSON'.format(name)
+        response = self.connect_to_service('PubChem', args)
+        if response.status_code == 200:
+            for prop in response.json()['PC_Compounds'][0]['props']:
+                if prop['urn']['label'] == 'InChI':
+                    return prop['value']['sval']
+
+    def inchi_to_IUPAC_name(self, inchi):
+        args = "inchi/JSON"
+        response = self.connect_to_service('PubChem', args, method='POST', data={'inchi': inchi})
+        if response.status_code == 200:
+            for prop in response.json()['PC_Compounds'][0]['props']:
+                if prop['urn']['label'] == 'IUPAC Name' and prop['urn']['name'] == 'Preferred':
+                    return prop['value']['sval']
+
+    def inchi_to_formula(self, inchi):
+        args = "inchi/JSON"
+        response = self.connect_to_service('PubChem', args, method='POST', data={'inchi': inchi})
+        if response.status_code == 200:
+            for prop in response.json()['PC_Compounds'][0]['props']:
+                if prop['urn']['label'] == 'Molecular Formula':
+                    return prop['value']['sval']
+
+    def inchi_to_smiles(self, inchi):
+        args = "inchi/JSON"
+        response = self.connect_to_service('PubChem', args, method='POST', data={'inchi': inchi})
+        if response.status_code == 200:
+            for prop in response.json()['PC_Compounds'][0]['props']:
+                if prop['urn']['label'] == 'SMILES' and prop['urn']['name'] == 'Canonical':
+                    return prop['value']['sval']

--- a/libs/services/PubChem.py
+++ b/libs/services/PubChem.py
@@ -7,15 +7,14 @@ class PubChem(Converter):
         # service URLs
         self.services = {'PubChem': 'https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/'}
 
-    def inchi_to_inchikey(self, inchi):
-        args = "inchi/JSON"
-        response = self.connect_to_service('PubChem', args, method='POST', data={'inchi': inchi})
-        if response.status_code == 200:
-            for prop in response.json()['PC_Compounds'][0]['props']:
-                if prop['urn']['label'] == 'InChIKey':
-                    return prop['value']['sval']
-
     def name_to_inchi(self, name):
+        """
+        Convert Chemical name to InChi using PubChem service
+        More info: https://pubchemdocs.ncbi.nlm.nih.gov/pug-rest
+
+        :param name: given Chemical name
+        :return: found InChi
+        """
         args = 'name/{}/JSON'.format(name)
         response = self.connect_to_service('PubChem', args)
         if response.status_code == 200:
@@ -23,26 +22,70 @@ class PubChem(Converter):
                 if prop['urn']['label'] == 'InChI':
                     return prop['value']['sval']
 
+    def inchi_to_inchikey(self, inchi):
+        """
+        Convert InChi to InChiKey using PubChem service
+        More info: https://pubchemdocs.ncbi.nlm.nih.gov/pug-rest
+
+        :param inchi: given InChi
+        :return: found InChiKey
+        """
+        props = self.get_props_from_inchi(inchi)
+        if props:
+            for prop in props:
+                if prop['urn']['label'] == 'InChIKey':
+                    return prop['value']['sval']
+
     def inchi_to_IUPAC_name(self, inchi):
-        args = "inchi/JSON"
-        response = self.connect_to_service('PubChem', args, method='POST', data={'inchi': inchi})
-        if response.status_code == 200:
-            for prop in response.json()['PC_Compounds'][0]['props']:
+        """
+        Convert InChi to IUPAC name using PubChem service
+        More info: https://pubchemdocs.ncbi.nlm.nih.gov/pug-rest
+
+        :param inchi: given InChi
+        :return: found IUPAC name
+        """
+        props = self.get_props_from_inchi(inchi)
+        if props:
+            for prop in props:
                 if prop['urn']['label'] == 'IUPAC Name' and prop['urn']['name'] == 'Preferred':
                     return prop['value']['sval']
 
     def inchi_to_formula(self, inchi):
-        args = "inchi/JSON"
-        response = self.connect_to_service('PubChem', args, method='POST', data={'inchi': inchi})
-        if response.status_code == 200:
-            for prop in response.json()['PC_Compounds'][0]['props']:
+        """
+        Convert InChi to chemical formula using PubChem service
+        More info: https://pubchemdocs.ncbi.nlm.nih.gov/pug-rest
+
+        :param inchi: given InChi
+        :return: found chemical formula
+        """
+        props = self.get_props_from_inchi(inchi)
+        if props:
+            for prop in props:
                 if prop['urn']['label'] == 'Molecular Formula':
                     return prop['value']['sval']
 
     def inchi_to_smiles(self, inchi):
+        """
+        Convert InChi to SMILES using PubChem service
+        More info: https://pubchemdocs.ncbi.nlm.nih.gov/pug-rest
+
+        :param inchi: given InChi
+        :return: found SMILES
+        """
+        props = self.get_props_from_inchi(inchi)
+        if props:
+            for prop in props:
+                if prop['urn']['label'] == 'SMILES' and prop['urn']['name'] == 'Canonical':
+                    return prop['value']['sval']
+
+    def get_props_from_inchi(self, inchi):
+        """
+        General methods to obtain all possible data based on InChi.
+
+        :param inchi: given InChi
+        :return: obtained properties associated to the given InChi
+        """
         args = "inchi/JSON"
         response = self.connect_to_service('PubChem', args, method='POST', data={'inchi': inchi})
         if response.status_code == 200:
-            for prop in response.json()['PC_Compounds'][0]['props']:
-                if prop['urn']['label'] == 'SMILES' and prop['urn']['name'] == 'Canonical':
-                    return prop['value']['sval']
+            return response.json()['PC_Compounds'][0]['props']

--- a/libs/services/PubChem.py
+++ b/libs/services/PubChem.py
@@ -15,7 +15,7 @@ class PubChem(Converter):
         :param name: given Chemical name
         :return: found InChi
         """
-        args = 'name/{}/JSON'.format(name)
+        args = f'name/{name}/JSON'
         response = self.connect_to_service('PubChem', args)
         if response.status_code == 200:
             for prop in response.json()['PC_Compounds'][0]['props']:

--- a/tests/test_CIR.py
+++ b/tests/test_CIR.py
@@ -39,7 +39,7 @@ class TestCIR(unittest.TestCase):
 
     def test_inchikey_to_inchi(self):
         inchikey = 'XQLMNMQWVCXIKR-UHFFFAOYSA-M'
-        inchi = '1S/Ag.BrHO3/c;2-1(3)4/h;(H,2,3,4)/q+1;/p-1'
+        inchi = 'InChI=1S/Ag.BrHO3/c;2-1(3)4/h;(H,2,3,4)/q+1;/p-1'
         self.assertEqual(self.converter.inchikey_to_inchi(inchikey), inchi)
 
         inchikey = 'XQLMNVCXIKR-UHFFFAOYSA-M'

--- a/tests/test_CTS.py
+++ b/tests/test_CTS.py
@@ -44,7 +44,7 @@ class TestCTS(unittest.TestCase):
 
     def test_inchikey_to_inchi(self):
         inchikey = 'XQLMNMQWVCXIKR-UHFFFAOYSA-M'
-        inchi = '1S/Ag.BrHO3/c;2-1(3)4/h;(H,2,3,4)/q+1;/p-1'
+        inchi = 'InChI=1S/Ag.BrHO3/c;2-1(3)4/h;(H,2,3,4)/q+1;/p-1'
         self.assertEqual(self.converter.inchikey_to_inchi(inchikey), inchi)
 
         inchikey = 'XQLMNMQIKR-UHFFFAOYSA-M'

--- a/tests/test_pubchem.py
+++ b/tests/test_pubchem.py
@@ -1,0 +1,63 @@
+import unittest
+
+from libs.services.PubChem import PubChem
+
+
+class TestCTS(unittest.TestCase):
+    def setUp(self):
+        self.converter = PubChem()
+
+    def test_connect_to_service(self):
+        pass
+
+    def test_inchi_to_inchikey(self):
+        inchi = 'InChI=1S/C9H10O4/c10-7-3-1-6(2-4-7)5-8(11)9(12)13/h1-4,8,10-11H,5H2,(H,12,13)'
+        inchikey = 'JVGVDSSUAVXRDY-UHFFFAOYSA-N'
+        self.assertEqual(self.converter.inchi_to_inchikey(inchi), inchikey)
+
+        # clear the cache
+        self.converter.cache = dict()
+
+        wrong_inchi = 'InChI=1S/C9H10O4/c102-4-7)5-8(11)9(12)13/h1-4,8,10-11H,5H2,(H,12,13)'
+        self.assertIsNone(self.converter.inchi_to_inchikey(wrong_inchi))
+
+    def test_name_to_inchi(self):
+        name = '3-Methyl-5-[p-fluorophenyl]-2H-1,3-[3H]-oxazine-2,6-dione'
+        inchi = 'InChI=1S/C11H8FNO3/c1-13-6-9(10(14)16-11(13)15)7-2-4-8(12)5-3-7/h2-6H,1H3'
+        self.assertEqual(self.converter.name_to_inchi(name), inchi)
+
+        name = 'HYDROXYPHENYLLACTATE M-H'
+        self.assertIsNone(self.converter.name_to_inchi(name))
+
+    def test_inchi_to_IUPAC_name(self):
+        inchi = 'InChI=1S/C11H8FNO3/c1-13-6-9(10(14)16-11(13)15)7-2-4-8(12)5-3-7/h2-6H,1H3'
+        IUPAC_name = '5-(4-fluorophenyl)-3-methyl-1,3-oxazine-2,6-dione'
+        self.assertEqual(self.converter.inchi_to_IUPAC_name(inchi), IUPAC_name)
+
+        # clear the cache
+        self.converter.cache = dict()
+
+        wrong_inchi = 'InChI=1S/C9H10O4/c102-4-7)5-8(11)93/1-4,8,10-11H,5H2,(H,12,13)'
+        self.assertIsNone(self.converter.inchi_to_IUPAC_name(wrong_inchi))
+
+    def test_inchi_to_formula(self):
+        inchi = 'InChI=1S/C11H8FNO3/c1-13-6-9(10(14)16-11(13)15)7-2-4-8(12)5-3-7/h2-6H,1H3'
+        formula = 'C11H8FNO3'
+        self.assertEqual(self.converter.inchi_to_formula(inchi), formula)
+
+        # clear the cache
+        self.converter.cache = dict()
+
+        wrong_inchi = 'InChI=1S/C9H10O4/c102-4-7)5-8(11)93/1-4,8,10-11H,5H2,(H,12,13)'
+        self.assertIsNone(self.converter.inchi_to_formula(wrong_inchi))
+
+    def test_inchi_to_smiles(self):
+        inchi = 'InChI=1S/C11H8FNO3/c1-13-6-9(10(14)16-11(13)15)7-2-4-8(12)5-3-7/h2-6H,1H3'
+        smiles = 'CN1C=C(C(=O)OC1=O)C2=CC=C(C=C2)F'
+        self.assertEqual(self.converter.inchi_to_smiles(inchi), smiles)
+
+        # clear the cache
+        self.converter.cache = dict()
+
+        wrong_inchi = 'InChI=1S/C9H10O4/c102-4-7)5-8(11)93/1-4,8,10-11H,5H2,(H,12,13)'
+        self.assertIsNone(self.converter.inchi_to_smiles(wrong_inchi))

--- a/tests/test_pubchem.py
+++ b/tests/test_pubchem.py
@@ -8,7 +8,15 @@ class TestCTS(unittest.TestCase):
         self.converter = PubChem()
 
     def test_connect_to_service(self):
-        pass
+        inchi = 'InChI=1S/C9H10O4/c10-7-3-1-6(2-4-7)5-8(11)9(12)13/h1-4,8,10-11H,5H2,(H,12,13)'
+        args = "inchi/JSON"
+        response = self.converter.connect_to_service('PubChem', args, method='POST', data={'inchi': inchi})
+        self.assertEqual(response.status_code, 200)
+        json = response.json()
+        self.assertIn('PC_Compounds', json)
+        self.assertTrue(len(json['PC_Compounds']) == 1)
+        self.assertIn('props', json['PC_Compounds'][0])
+        self.assertTrue(type(json['PC_Compounds'][0]['props']) == list)
 
     def test_inchi_to_inchikey(self):
         inchi = 'InChI=1S/C9H10O4/c10-7-3-1-6(2-4-7)5-8(11)9(12)13/h1-4,8,10-11H,5H2,(H,12,13)'

--- a/tests/test_pubchem.py
+++ b/tests/test_pubchem.py
@@ -3,7 +3,7 @@ import unittest
 from libs.services.PubChem import PubChem
 
 
-class TestCTS(unittest.TestCase):
+class TestPubChem(unittest.TestCase):
     def setUp(self):
         self.converter = PubChem()
 


### PR DESCRIPTION
Provides PubChem service, which is particularly useful in identifying data by chemical name. Fixes #2 .

Also enabled general POST request, which was required by PubChem. This also includes arguments generalisation of `Converter.connect_to_service` method. Fixes #7 .