### PR TITLE
9 logging

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ import aiohttp
 from libs.Annotator import Annotator
 from libs.Curator import Curator
 from libs.Spectra import Spectra
+from libs.utils import logger
 from libs.utils.Errors import UnknownService, UnknownSpectraFormat
 from libs.utils.Job import convert_to_jobs
 from libs.services import *
@@ -79,8 +80,11 @@ class Application:
                 jobs = annotator.get_all_conversions()
             jobs = convert_to_jobs(jobs)
 
+            logger.set_target_attributes(jobs)
+
             for size in range(len(self.spectra.spectrums) // batch_size + 1):
                 results += await asyncio.gather(*[annotator.annotate(spectra, jobs, repeat) for spectra in
                                                   self.spectra.spectrums[size * batch_size:(size + 1) * batch_size]])
 
         self.spectra.spectrums = results
+        logger.log_statistics()

--- a/app.py
+++ b/app.py
@@ -11,8 +11,9 @@ from libs.services import *
 
 
 class Application:
-    def __init__(self, log_level='warning'):
+    def __init__(self, log_level='warning', log_file=None):
         self.log_level = log_level
+        self.log_file = log_file
         self.spectra = Spectra()
 
     @staticmethod
@@ -88,4 +89,4 @@ class Application:
                                                   self.spectra.spectrums[size * batch_size:(size + 1) * batch_size]])
 
         self.spectra.spectrums = results
-        logger.log_statistics(self.log_level)
+        logger.log_statistics(self.log_level, self.log_file)

--- a/app.py
+++ b/app.py
@@ -11,7 +11,8 @@ from libs.services import *
 
 
 class Application:
-    def __init__(self):
+    def __init__(self, log_level='warning'):
+        self.log_level = log_level
         self.spectra = Spectra()
 
     @staticmethod
@@ -87,4 +88,4 @@ class Application:
                                                   self.spectra.spectrums[size * batch_size:(size + 1) * batch_size]])
 
         self.spectra.spectrums = results
-        logger.log_statistics()
+        logger.log_statistics(self.log_level)

--- a/libs/Annotator.py
+++ b/libs/Annotator.py
@@ -35,14 +35,15 @@ class Annotator:
                         logger.add_success()
                         if repeat:
                             added_metadata = True
-                    except (SourceAttributeNotAvailable, ConversionNotSupported,
-                            TargetAttributeNotRetrieved, UnknownResponse) as exc:
+                    except (ConversionNotSupported, TargetAttributeNotRetrieved, UnknownResponse) as exc:
                         warning.add_warning(exc)
+                    except SourceAttributeNotAvailable as exc:
+                        warning.add_info(exc)
                     except ServiceNotAvailable:
                         warning.add_warning(ServiceNotAvailable(f'Service {job.service} not available.'))
                 else:
-                    warning.add_warning(Exception(f'Conversion ({job.service}) {job.source} -> {job.target}: Requested '
-                                                  f'attribute {job.target} already present in given metadata.'))
+                    warning.add_info(f'Conversion ({job.service}) {job.source} -> {job.target}: Requested '
+                                     f'attribute {job.target} already present in given metadata.')
 
         warning.compute_success_rate(metadata)
         logger.add_fails(warning.fails)

--- a/libs/Annotator.py
+++ b/libs/Annotator.py
@@ -23,7 +23,7 @@ class Annotator:
         """
         metadata = spectra.metadata
         cache = dict()
-        warning = LogWarning(metadata, logger.attribute_discovery_rates)
+        warning = LogWarning(dict(metadata), logger.attribute_discovery_rates)
 
         added_metadata = True
         while added_metadata:

--- a/libs/Annotator.py
+++ b/libs/Annotator.py
@@ -1,4 +1,5 @@
-from libs.utils.Errors import ConversionNotSupported, DataNotRetrieved, DataNotAvailable
+from libs.utils import logger
+from libs.utils.Errors import ConversionNotSupported, DataNotRetrieved, DataNotAvailable, ServiceNotAvailable
 
 
 class Annotator:
@@ -30,14 +31,13 @@ class Annotator:
                         metadata, cache = await self.execute_job_with_cache(job, metadata, cache)
                         if repeat:
                             added_metadata = True
-                    except DataNotAvailable:
-                        pass  # TODO log data for conversing missing in given metadata
-                    except ConversionNotSupported:
-                        pass  # TODO log this type of conversion is not supported by the service or service unknown
-                    except DataNotRetrieved:
-                        pass  # TODO log no data were retrieved
+                    except (DataNotAvailable, ConversionNotSupported, DataNotRetrieved) as exc:
+                        logger.warning(exc, metadata)
+                    except ServiceNotAvailable:
+                        logger.warning(ServiceNotAvailable(f'Service {job.service} not available.'))
                 else:
-                    pass  # TODO: log - data already present
+                    logger.warning(Exception(f'Requested attribute {job.target} already present in given metadata'),
+                                   metadata)
 
         spectra.metadata = metadata
         return spectra

--- a/libs/Annotator.py
+++ b/libs/Annotator.py
@@ -23,7 +23,7 @@ class Annotator:
         """
         metadata = spectra.metadata
         cache = dict()
-        warning = LogWarning(metadata, logger.target_attributes)
+        warning = LogWarning(metadata, logger.attribute_discovery_rates)
 
         added_metadata = True
         while added_metadata:
@@ -44,7 +44,7 @@ class Annotator:
                     warning.add_warning(Exception(f'Conversion ({job.service}) {job.source} -> {job.target}: Requested '
                                                   f'attribute {job.target} already present in given metadata.'))
 
-        warning.compute_success_rate()
+        warning.compute_success_rate(metadata)
         logger.add_fails(warning.fails)
         logger.add_warning(warning)
 

--- a/libs/Annotator.py
+++ b/libs/Annotator.py
@@ -57,7 +57,7 @@ class Annotator:
         Execute given job in cached mode. Cache is service specific
         and spectra specific.
 
-        Raises TargetAttributeDNotRetrieved
+        Raises TargetAttributeNotRetrieved
 
         :param job: given job to be executed
         :param metadata: data to be annotated by the job

--- a/libs/services/CIR.py
+++ b/libs/services/CIR.py
@@ -7,7 +7,7 @@ class CIR(Converter):
         # service URLs
         self.services = {'CIR': 'https://cactus.nci.nih.gov/chemical/structure/'}
 
-    async def cas_to_smiles(self, cas_number):
+    async def casno_to_smiles(self, cas_number):
         """
         Convert CAS number to SMILES using CIR web service
         More info: https://cactus.nci.nih.gov/chemical/structure_documentation
@@ -46,7 +46,7 @@ class CIR(Converter):
         if response:
             return {'inchi': response}
 
-    async def inchikey_to_cas(self, inchikey):
+    async def inchikey_to_casno(self, inchikey):
         """
         Convert InChiKey to CAS number using CIR web service
         More info: https://cactus.nci.nih.gov/chemical/structure_documentation

--- a/libs/services/CTS.py
+++ b/libs/services/CTS.py
@@ -19,7 +19,7 @@ class CTS(Converter):
 
     ### top level methods defining allowed conversions
 
-    async def cas_to_inchikey(self, cas_number):
+    async def casno_to_inchikey(self, cas_number):
         """
         Convert CAS number to InChiKey using CTS web service
         More info: http://cts.fiehnlab.ucdavis.edu/services

--- a/libs/services/Converter.py
+++ b/libs/services/Converter.py
@@ -1,13 +1,20 @@
+import aiohttp
 from asyncstdlib import lru_cache
 
 
 from aiohttp.client_exceptions import ServerDisconnectedError
-from libs.utils.Errors import DataNotRetrieved, ConversionNotSupported
+
+from libs.utils import logger
+from libs.utils.Errors import DataNotRetrieved, ServiceNotAvailable
 
 
 class Converter:
     def __init__(self, session):
         self.session = session
+
+    @property
+    def service_name(self):
+        return self.__class__.__name__
 
     @lru_cache
     async def query_the_service(self, service, args, method='GET', data=None):
@@ -25,7 +32,7 @@ class Converter:
             result = await self.loop_request(self.services[service] + args, method, data)
             return result
         except TypeError:
-            pass  # TODO: log - probably given argument is incorrect
+            logger.warning(TypeError(f'Incorrect argument {args} for service {service}.'))
 
     async def loop_request(self, url, method, data, depth=10):
         """
@@ -44,9 +51,10 @@ class Converter:
             else:
                 async with self.session.post(url=url, data=data) as response:
                     return await self.process_request(response, url, method, data, depth)
-        except ServerDisconnectedError:
+        except (ServerDisconnectedError, aiohttp.client_exceptions.ClientConnectorError):
             if depth > 0:
                 return await self.loop_request(url, method, data, depth - 1)
+            raise ServiceNotAvailable
 
     async def process_request(self, response, url, method, data, depth):
         """
@@ -63,10 +71,11 @@ class Converter:
         if response.ok:
             return result
         elif response.status == 503:
+            # server busy, try again
             if depth > 0:
                 return await self.loop_request(url, method, data, depth - 1)
         else:
-            pass  # TODO: log - other error responses
+            logger.warning(f'Unknown response {response.status}:{result} for {method} request on {url} with {data}.')
 
     async def convert(self, source, target, data):
         """
@@ -77,13 +86,10 @@ class Converter:
         :param data: given attribute value
         :return: obtained value of target attribute
         """
-        try:
-            result = await getattr(self, f'{source}_to_{target}')(data)
-            if result:
-                return result
-            raise DataNotRetrieved(f'Target attribute {target} not available.')
-        except AttributeError:
-            raise ConversionNotSupported(f'Conversion from {source} to {target} is not supported.')
+        result = await getattr(self, f'{source}_to_{target}')(data)
+        if result:
+            return result
+        raise DataNotRetrieved(f'No data were retrieved for {self.service_name}: {source} -> {target}.')
 
     def create_top_level_conversion_methods(self, conversions):
         """

--- a/libs/services/Converter.py
+++ b/libs/services/Converter.py
@@ -93,7 +93,9 @@ class Converter:
         result = await getattr(self, f'{source}_to_{target}')(data)
         if result:
             return result
-        raise TargetAttributeNotRetrieved(f'Conversion ({self.service_name}) {source} -> {target}: no data retrieved.')
+        else:
+            raise TargetAttributeNotRetrieved(f'Conversion ({self.service_name}) {source} -> {target}: '
+                                              f'no data retrieved.')
 
     def create_top_level_conversion_methods(self, conversions):
         """

--- a/libs/utils/Errors.py
+++ b/libs/utils/Errors.py
@@ -2,7 +2,7 @@ class ConversionNotSupported(Exception):
     pass
 
 
-class TargetAttributeDNotRetrieved(Exception):
+class TargetAttributeNotRetrieved(Exception):
     pass
 
 
@@ -19,4 +19,8 @@ class SourceAttributeNotAvailable(Exception):
 
 
 class ServiceNotAvailable(Exception):
+    pass
+
+
+class UnknownResponse(Exception):
     pass

--- a/libs/utils/Errors.py
+++ b/libs/utils/Errors.py
@@ -16,3 +16,7 @@ class UnknownSpectraFormat(Exception):
 
 class DataNotAvailable(Exception):
     pass
+
+
+class ServiceNotAvailable(Exception):
+    pass

--- a/libs/utils/Errors.py
+++ b/libs/utils/Errors.py
@@ -2,7 +2,7 @@ class ConversionNotSupported(Exception):
     pass
 
 
-class DataNotRetrieved(Exception):
+class TargetAttributeDNotRetrieved(Exception):
     pass
 
 
@@ -14,7 +14,7 @@ class UnknownSpectraFormat(Exception):
     pass
 
 
-class DataNotAvailable(Exception):
+class SourceAttributeNotAvailable(Exception):
     pass
 
 

--- a/libs/utils/Job.py
+++ b/libs/utils/Job.py
@@ -6,7 +6,7 @@ class Job:
         self.source, self.target, self.service = data
 
     def __str__(self):
-        return f'{self.source} -> {self.target} : {self.service}'
+        return f'{self.service}: {self.source} -> {self.target}'
 
     def __repr__(self):
         return f'Job(({self.source}, {self.target}, {self.service}))'
@@ -16,9 +16,10 @@ class Job:
         data = metadata.get(self.source, None)
 
         if service is None:
-            raise ConversionNotSupported(f'Specified {service} not supported.')
+            raise ConversionNotSupported(f'Conversion {self.source} -> {self.target} is not supported '
+                                         f'by the service: {self.service}')
         elif data is None:
-            raise DataNotAvailable(f'Source {self.source} not available in metadata.')
+            raise DataNotAvailable(f'Attribute {self.source} missing in given metadata.')
         else:
             return service, data
 

--- a/libs/utils/Job.py
+++ b/libs/utils/Job.py
@@ -1,4 +1,4 @@
-from libs.utils.Errors import ConversionNotSupported, DataNotAvailable
+from libs.utils.Errors import ConversionNotSupported, SourceAttributeNotAvailable
 
 
 class Job:
@@ -19,7 +19,7 @@ class Job:
             raise ConversionNotSupported(f'Conversion {self.source} -> {self.target} is not supported '
                                          f'by the service: {self.service}')
         elif data is None:
-            raise DataNotAvailable(f'Attribute {self.source} missing in given metadata.')
+            raise SourceAttributeNotAvailable(f'Attribute {self.source} missing in given metadata.')
         else:
             return service, data
 

--- a/libs/utils/Job.py
+++ b/libs/utils/Job.py
@@ -16,10 +16,10 @@ class Job:
         data = metadata.get(self.source, None)
 
         if service is None:
-            raise ConversionNotSupported(f'Conversion {self.source} -> {self.target} is not supported '
-                                         f'by the service: {self.service}')
+            raise ConversionNotSupported(f'Conversion ({self.service}) {self.source} -> {self.target}: is not supported')
         elif data is None:
-            raise SourceAttributeNotAvailable(f'Attribute {self.source} missing in given metadata.')
+            raise SourceAttributeNotAvailable(f'Conversion ({self.service}) {self.source} -> {self.target}: '
+                                              f'Attribute {self.source} missing in given metadata.')
         else:
             return service, data
 

--- a/libs/utils/Logger.py
+++ b/libs/utils/Logger.py
@@ -1,0 +1,21 @@
+import logging
+
+
+class Logger:
+    def __init__(self):
+        self.logger = logging.getLogger('log')
+        self.logger.setLevel('WARNING')
+
+        filehandler_dbg = logging.FileHandler('MSPannotator.log', mode='w')
+        filehandler_dbg.setLevel('DEBUG')
+
+        streamformatter = logging.Formatter(fmt='%(levelname)s: %(message)s')
+
+        # Apply formatters to handlers
+        filehandler_dbg.setFormatter(streamformatter)
+
+        # Add handlers to logger
+        self.logger.addHandler(filehandler_dbg)
+
+    def warning(self, exc: Exception, message=None):
+        self.logger.warning(f'{exc}\nMetadata: {message}\n' if message else f'{exc}\n')

--- a/libs/utils/Logger.py
+++ b/libs/utils/Logger.py
@@ -4,7 +4,7 @@ import logging
 class Logger:
     def __init__(self):
         self.logger = logging.getLogger('log')
-        self.logger.setLevel('WARNING')
+        self.logger.setLevel('INFO')
 
         filehandler_dbg = logging.FileHandler('MSPannotator.log', mode='w')
         filehandler_dbg.setLevel('DEBUG')
@@ -17,5 +17,60 @@ class Logger:
         # Add handlers to logger
         self.logger.addHandler(filehandler_dbg)
 
-    def warning(self, exc: Exception, message=None):
-        self.logger.warning(f'{exc}\nMetadata: {message}\n' if message else f'{exc}\n')
+        # statistical values
+        self.passes = 0
+        self.fails = 0
+        self.target_attributes = set()
+        self.attribute_discovery_rate = 1
+
+    def set_target_attributes(self, jobs):
+        """
+        Gather all target attributes from specified jobs
+
+        :param jobs: given list of jobs
+        """
+        self.target_attributes = {job.target for job in jobs}
+
+    def warning(self, exc: Exception, metadata=None):
+        """
+        Logs given exception as a Warning.
+        Increases number of failed jobs.
+
+        :param exc: given exception
+        :param metadata: additional metadata
+        """
+        self.fails += 1
+        self.logger.warning(f'{exc}\nMetadata: {metadata}\n' if metadata else f'{exc}\n')
+
+    def info(self, message):
+        """
+        Logs given message as a Warning.
+
+        :param message: message to be logged
+        """
+        self.logger.warning(message + '\n')
+
+    def success(self):
+        """
+        Increase number of passed jobs.
+        """
+        self.passes += 1
+
+    def compute_success_rate(self, metadata):
+        """
+        Compute success rate of attribute discovery.
+
+        Based on ratio of found attributes to target attributes.
+
+        :param metadata: found metadata (includes also already present attributes)
+        """
+        rate = len(metadata.keys() & self.target_attributes)/len(self.target_attributes)
+        self.attribute_discovery_rate = (self.attribute_discovery_rate + rate)/2
+
+    def log_statistics(self):
+        """
+        Log obtained statistical values as Info.
+        """
+        self.logger.info(f'Job success rate: {self.passes}/{self.passes + self.fails} '
+                         f'({self.passes/(self.passes + self.fails)}%)')
+        self.logger.info(f'Attribute discovery rate: {self.attribute_discovery_rate*100}%')

--- a/libs/utils/__init__.py
+++ b/libs/utils/__init__.py
@@ -1,0 +1,3 @@
+from libs.utils.Logger import Logger
+
+logger = Logger()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ mock~=4.0.3
 aiohttp~=3.7.4.post0
 asyncstdlib~=3.9.2
 frozendict~=2.0.3
+tabulate~=0.8.9

--- a/tests/test_CIR.py
+++ b/tests/test_CIR.py
@@ -2,6 +2,7 @@ import asyncio
 import unittest
 
 from libs.services.CIR import CIR
+from libs.utils.Errors import UnknownResponse
 from tests.utils import wrap_with_session
 
 
@@ -19,17 +20,18 @@ class TestCIR(unittest.TestCase):
         # incorrect CAS number
         cas_number = '7783893'
         args = '{}/smiles?resolver=cas_number'.format(cas_number)
-        response = asyncio.run(wrap_with_session(self.converter, 'query_the_service', ['CIR', args]))
-        self.assertIsNone(response)
+        with self.assertRaises(UnknownResponse):
+            asyncio.run(wrap_with_session(self.converter, 'query_the_service', ['CIR', args]))
 
-    def test_cas_to_smiles(self):
+    def test_casno_to_smiles(self):
         smiles = '[Ag+].[O-][Br](=O)=O'
         cas_number = '7783-89-3'
-        self.assertEqual(asyncio.run(wrap_with_session(self.converter, 'cas_to_smiles', [cas_number]))['smiles'],
+        self.assertEqual(asyncio.run(wrap_with_session(self.converter, 'casno_to_smiles', [cas_number]))['smiles'],
                          smiles)
 
         cas_number = '7783893'
-        self.assertIsNone(asyncio.run(wrap_with_session(self.converter, 'cas_to_smiles', [cas_number])))
+        with self.assertRaises(UnknownResponse):
+            asyncio.run(wrap_with_session(self.converter, 'casno_to_smiles', [cas_number]))
 
     def test_inchikey_to_smiles(self):
         inchikey = 'XQLMNMQWVCXIKR-UHFFFAOYSA-M'
@@ -38,7 +40,8 @@ class TestCIR(unittest.TestCase):
                          smiles)
 
         inchikey = 'XQLMNVCXIKR-UHFFFAOYSA-M'
-        self.assertIsNone(asyncio.run(wrap_with_session(self.converter, 'inchikey_to_smiles', [inchikey])))
+        with self.assertRaises(UnknownResponse):
+            asyncio.run(wrap_with_session(self.converter, 'inchikey_to_smiles', [inchikey]))
 
     def test_inchikey_to_inchi(self):
         inchikey = 'XQLMNMQWVCXIKR-UHFFFAOYSA-M'
@@ -48,17 +51,19 @@ class TestCIR(unittest.TestCase):
                          inchi)
 
         inchikey = 'XQLMNVCXIKR-UHFFFAOYSA-M'
-        self.assertIsNone(asyncio.run(wrap_with_session(self.converter, 'inchikey_to_inchi', [inchikey])))
+        with self.assertRaises(UnknownResponse):
+            asyncio.run(wrap_with_session(self.converter, 'inchikey_to_inchi', [inchikey]))
 
     def test_inchikey_to_cas(self):
         inchikey = 'XQLMNMQWVCXIKR-UHFFFAOYSA-M'
         cas_number = '7783-89-3'
 
-        self.assertEqual(asyncio.run(wrap_with_session(self.converter, 'inchikey_to_cas', [inchikey]))['casno'],
+        self.assertEqual(asyncio.run(wrap_with_session(self.converter, 'inchikey_to_casno', [inchikey]))['casno'],
                          cas_number)
 
         inchikey = 'XQLMNVCXIKR-UHFFFAOYSA-M'
-        self.assertIsNone(asyncio.run(wrap_with_session(self.converter, 'inchikey_to_cas', [inchikey])))
+        with self.assertRaises(UnknownResponse):
+            asyncio.run(wrap_with_session(self.converter, 'inchikey_to_casno', [inchikey]))
 
     def test_inchikey_to_formula(self):
         inchikey = 'XQLMNMQWVCXIKR-UHFFFAOYSA-M'
@@ -68,7 +73,8 @@ class TestCIR(unittest.TestCase):
                          formula)
 
         inchikey = 'XQLMNVCXIKR-UHFFFAOYSA-M'
-        self.assertIsNone(asyncio.run(wrap_with_session(self.converter, 'inchikey_to_formula', [inchikey])))
+        with self.assertRaises(UnknownResponse):
+            asyncio.run(wrap_with_session(self.converter, 'inchikey_to_formula', [inchikey]))
 
     def test_smiles_to_inchikey(self):
         inchikey = 'XQLMNMQWVCXIKR-UHFFFAOYSA-M'
@@ -78,4 +84,5 @@ class TestCIR(unittest.TestCase):
                          inchikey)
 
         smiles = '[Ag+].O-][Br](=O)=O'
-        self.assertIsNone(asyncio.run(wrap_with_session(self.converter, 'smiles_to_inchikey', [smiles])))
+        with self.assertRaises(UnknownResponse):
+            asyncio.run(wrap_with_session(self.converter, 'smiles_to_inchikey', [smiles]))

--- a/tests/test_CTS.py
+++ b/tests/test_CTS.py
@@ -3,6 +3,7 @@ import unittest
 import json
 
 from libs.services.CTS import CTS
+from libs.utils.Errors import UnknownResponse
 from tests.utils import wrap_with_session
 
 
@@ -34,11 +35,11 @@ class TestCTS(unittest.TestCase):
     def test_cas_to_inchikey(self):
         inchikey = 'XQLMNMQWVCXIKR-UHFFFAOYSA-M'
         cas_number = '7783-89-3'
-        self.assertEqual(asyncio.run(wrap_with_session(self.converter, 'cas_to_inchikey', [cas_number]))['inchikey'],
+        self.assertEqual(asyncio.run(wrap_with_session(self.converter, 'casno_to_inchikey', [cas_number]))['inchikey'],
                          inchikey)
 
         cas_number = '7783893'
-        self.assertIsNone(asyncio.run(wrap_with_session(self.converter, 'cas_to_inchikey', [cas_number])))
+        self.assertIsNone(asyncio.run(wrap_with_session(self.converter, 'casno_to_inchikey', [cas_number])))
 
     def test_inchikey_to_inchi(self):
         inchikey = 'XQLMNMQWVCXIKR-UHFFFAOYSA-M'
@@ -48,7 +49,8 @@ class TestCTS(unittest.TestCase):
                          inchi)
 
         inchikey = 'XQLMNMQIKR-UHFFFAOYSA-M'
-        self.assertIsNone(asyncio.run(wrap_with_session(self.converter, 'inchikey_to_inchi', [inchikey])))
+        with self.assertRaises(UnknownResponse):
+            asyncio.run(wrap_with_session(self.converter, 'inchikey_to_inchi', [inchikey]))
 
     def test_name_to_inchikey(self):
         name = 'L-Alanine'
@@ -66,7 +68,8 @@ class TestCTS(unittest.TestCase):
         self.assertEqual(asyncio.run(wrap_with_session(self.converter, 'inchikey_to_name', [inchikey]))['name'], name)
 
         inchikey = 'XQLMNMQIKR-UHFFFAOYSA-M'
-        self.assertIsNone(asyncio.run(wrap_with_session(self.converter, 'inchikey_to_name', [inchikey])))
+        with self.assertRaises(UnknownResponse):
+            asyncio.run(wrap_with_session(self.converter, 'inchikey_to_name', [inchikey]))
 
     def test_inchikey_to_IUPAC_name(self):
         inchikey = 'QNAYBMKLOCPYGJ-REOHCLBHSA-N'
@@ -76,4 +79,5 @@ class TestCTS(unittest.TestCase):
                                                        [inchikey]))['iupac_name'], iupac_name)
 
         inchikey = 'XQLMNMQIKR-UHFFFAOYSA-M'
-        self.assertIsNone(asyncio.run(wrap_with_session(self.converter, 'inchikey_to_iupac_name', [inchikey])))
+        with self.assertRaises(UnknownResponse):
+            asyncio.run(wrap_with_session(self.converter, 'inchikey_to_iupac_name', [inchikey]))

--- a/tests/test_NLM.py
+++ b/tests/test_NLM.py
@@ -4,6 +4,7 @@ from io import StringIO
 import pandas as pd
 
 from libs.services.NLM import NLM
+from libs.utils.Errors import UnknownResponse
 from tests.utils import wrap_with_session
 
 
@@ -27,7 +28,8 @@ class TestNLM(unittest.TestCase):
         self.assertEqual(asyncio.run(wrap_with_session(self.converter, 'inchikey_to_name', [inchikey]))['name'], name)
 
         inchikey = 'QNAYBMLOXXXXGJ-REOHCLBHSA-N'
-        self.assertIsNone(asyncio.run(wrap_with_session(self.converter, 'inchikey_to_name', [inchikey])))
+        with self.assertRaises(UnknownResponse):
+            asyncio.run(wrap_with_session(self.converter, 'inchikey_to_name', [inchikey]))
 
         inchikey = 'QNAYMLGJ-REOLBHSA-N'
         self.assertIsNone(asyncio.run(wrap_with_session(self.converter, 'inchikey_to_name', [inchikey])))
@@ -40,4 +42,5 @@ class TestNLM(unittest.TestCase):
                          inchikey)
 
         name = 'L-Alanne'
-        self.assertIsNone(asyncio.run(wrap_with_session(self.converter, 'name_to_inchikey', [name])))
+        with self.assertRaises(UnknownResponse):
+            asyncio.run(wrap_with_session(self.converter, 'name_to_inchikey', [name]))

--- a/tests/test_pubchem.py
+++ b/tests/test_pubchem.py
@@ -4,6 +4,8 @@ import json
 
 from libs.services.PubChem import PubChem
 from frozendict import frozendict
+
+from libs.utils.Errors import UnknownResponse
 from tests.utils import wrap_with_session
 
 
@@ -30,7 +32,8 @@ class TestPubChem(unittest.TestCase):
                          inchikey)
 
         inchi = 'InChI=1S/C9H10O4/c102-4-7)5-8(11)9(12)13/h1-4,8,10-11H,5H2,(H,12,13)'
-        self.assertIsNone(asyncio.run(wrap_with_session(self.converter, 'inchi_to_inchikey', [inchi])))
+        with self.assertRaises(UnknownResponse):
+            asyncio.run(wrap_with_session(self.converter, 'inchi_to_inchikey', [inchi]))
 
     def test_name_to_inchi(self):
         name = '3-Methyl-5-[p-fluorophenyl]-2H-1,3-[3H]-oxazine-2,6-dione'
@@ -39,7 +42,8 @@ class TestPubChem(unittest.TestCase):
         self.assertEqual(asyncio.run(wrap_with_session(self.converter, 'name_to_inchi', [name]))['inchi'], inchi)
 
         name = 'HYDROXYPHENYLLACTATE M-H'
-        self.assertIsNone(asyncio.run(wrap_with_session(self.converter, 'name_to_inchi', [name])))
+        with self.assertRaises(UnknownResponse):
+            asyncio.run(wrap_with_session(self.converter, 'name_to_inchi', [name]))
 
     def test_inchi_to_IUPAC_name(self):
         inchi = 'InChI=1S/C11H8FNO3/c1-13-6-9(10(14)16-11(13)15)7-2-4-8(12)5-3-7/h2-6H,1H3'
@@ -49,7 +53,8 @@ class TestPubChem(unittest.TestCase):
                          IUPAC_name)
 
         inchi = 'InChI=1S/C9H10O4/c102-4-7)5-8(11)93/1-4,8,10-11H,5H2,(H,12,13)'
-        self.assertIsNone(asyncio.run(wrap_with_session(self.converter, 'inchi_to_iupac_name', [inchi])))
+        with self.assertRaises(UnknownResponse):
+         asyncio.run(wrap_with_session(self.converter, 'inchi_to_iupac_name', [inchi]))
 
     def test_inchi_to_formula(self):
         inchi = 'InChI=1S/C11H8FNO3/c1-13-6-9(10(14)16-11(13)15)7-2-4-8(12)5-3-7/h2-6H,1H3'
@@ -59,7 +64,8 @@ class TestPubChem(unittest.TestCase):
                          formula)
 
         inchi = 'InChI=1S/C9H10O4/c102-4-7)5-8(11)93/1-4,8,10-11H,5H2,(H,12,13)'
-        self.assertIsNone(asyncio.run(wrap_with_session(self.converter, 'inchi_to_formula', [inchi])))
+        with self.assertRaises(UnknownResponse):
+            asyncio.run(wrap_with_session(self.converter, 'inchi_to_formula', [inchi]))
 
     def test_inchi_to_smiles(self):
         inchi = 'InChI=1S/C11H8FNO3/c1-13-6-9(10(14)16-11(13)15)7-2-4-8(12)5-3-7/h2-6H,1H3'
@@ -68,4 +74,5 @@ class TestPubChem(unittest.TestCase):
         self.assertEqual(asyncio.run(wrap_with_session(self.converter, 'inchi_to_smiles', [inchi]))['smiles'], smiles)
 
         inchi = 'InChI=1S/C9H10O4/c102-4-7)5-8(11)93/1-4,8,10-11H,5H2,(H,12,13)'
-        self.assertIsNone(asyncio.run(wrap_with_session(self.converter, 'inchi_to_smiles', [inchi])))
+        with self.assertRaises(UnknownResponse):
+            asyncio.run(wrap_with_session(self.converter, 'inchi_to_smiles', [inchi]))


### PR DESCRIPTION
Implemented logging functionality. Close #9.

In this version, all logs are written to a single text file (for now with fixed filename `MSPannotator.log`). On the top of the file, a header summarizes statistical properties of the annotation process. 

- `Job success rate` states how many jobs were actually executed and how many actually obtained any data (job efficiency). 
- `Attribute discovery rates` show percentage coverage _before_ and _after_ the annotation process, showing increase present attributes.

```
INFO: Job success rate: 20/260 (0.076%) 
Attribute discovery rates:

Target       Coverage    Coverage
attribute    before      after
-----------  ----------  ----------
casno        96.875%     96.875%
iupac_name   0.0%        96.875%
name         96.875%     96.875%
formula      96.875%     96.875%
inchikey     0.0%        96.875%
inchi        0.0%        96.875%
smiles       0.0%        96.875%
==================================================
```

Then individual warnings and errors follow. This probably should be parametrized to reduce the amount of produced data. Here is an example:

```
WARNING: Errors related to metadata:

{'name': '3-Methyl-5-[p-fluorophenyl]-2H-1,3-[3H]-oxazine-2,6-dione', 'formula': 'C11H8FNO3', 'mw': '221', 'casno': '7785-23-1', 'id': '100001', 'ri': '1886', 'comment': 'NIST MS# 213949, Seq# M5815 |RI:1886|', 'num peaks': '142'}

-> Conversion (PubChem) inchi -> formula: Requested attribute formula already present in given metadata.
-> Conversion (PubChem) inchi -> inchikey: Attribute inchi missing in given metadata.
-> Conversion (PubChem) inchi -> iupac_name: Attribute inchi missing in given metadata.
-> Conversion (PubChem) inchi -> smiles: Attribute inchi missing in given metadata.
-> Service PubChem not available.
-> Conversion (PubChem) name -> formula: Requested attribute formula already present in given metadata.
-> Conversion (NLM) inchikey -> casno: no data retrieved.
-> Conversion (NLM) inchikey -> formula: Requested attribute formula already present in given metadata.
-> Conversion (NLM) inchikey -> name: Requested attribute name already present in given metadata.
-> Conversion (NLM) name -> casno: Requested attribute casno already present in given metadata.
-> Conversion (NLM) name -> formula: Requested attribute formula already present in given metadata.
-> Conversion (NLM) name -> inchikey: Requested attribute inchikey already present in given metadata.
-> Conversion (CTS) casno -> inchikey: Requested attribute inchikey already present in given metadata.
-> Conversion (CTS) inchikey -> inchi: Requested attribute inchi already present in given metadata.
-> Conversion (CTS) inchikey -> iupac_name: Requested attribute iupac_name already present in given metadata.
-> Conversion (CTS) inchikey -> name: Requested attribute name already present in given metadata.
-> Conversion (CTS) name -> inchikey: Requested attribute inchikey already present in given metadata.
-> Conversion (CIR) casno -> smiles: Requested attribute smiles already present in given metadata.
-> Conversion (CIR) inchikey -> casno: Requested attribute casno already present in given metadata.
-> Service CIR not available.
-> Conversion (CIR) inchikey -> inchi: Requested attribute inchi already present in given metadata.
-> Conversion (CIR) inchikey -> smiles: Requested attribute smiles already present in given metadata.
-> Conversion (CIR) smiles -> inchikey: Requested attribute inchikey already present in given metadata.
...
```

We are open to any suggestions what should be added/changed.