### PR TITLE
replace pubchem API with IDSM SPARQL API

### DIFF
--- a/libs/services/Converter.py
+++ b/libs/services/Converter.py
@@ -54,10 +54,10 @@ class Converter:
         try:
             if method == 'GET':
                 async with self.session.get(url, headers=headers) as response:
-                    return await self.process_request(response, url, method, data, depth)
+                    return await self.process_request(response, url, method)
             else:
                 async with self.session.post(url, data=data, headers=headers) as response:
-                    return await self.process_request(response, url, method, data, depth)
+                    return await self.process_request(response, url, method)
         except (ServerDisconnectedError, aiohttp.client_exceptions.ClientConnectorError):
             if depth > 0:
                 logger.error(ServiceNotAvailable(f'Service {self.service_name} '
@@ -65,15 +65,13 @@ class Converter:
                 return await self.loop_request(url, method, data, headers, depth - 1)
             raise ServiceNotAvailable
 
-    async def process_request(self, response, url, method, data, depth):
+    async def process_request(self, response, url, method):
         """
         Method to wrap response handling (same for POST and GET requests).
 
         :param response: given async response
         :param url: service URL
         :param method: GET/POST
-        :param data: given arguments for POST request
-        :param depth: allowed recursion depth for unsuccessful requests
         :return: processed response
         """
         result = await response.text()

--- a/libs/services/Converter.py
+++ b/libs/services/Converter.py
@@ -20,7 +20,7 @@ class Converter:
         return hash(self.service_name)
 
     @lru_cache
-    async def query_the_service(self, service, args, method='GET', data=None):
+    async def query_the_service(self, service, args, method='GET', data=None, headers=None):
         """
         Make get request to given service with arguments.
         Raises ConnectionError if service is not available.
@@ -29,15 +29,16 @@ class Converter:
         :param args: additional query arguments
         :param method: GET (default) or POST
         :param data: data for POST request
+        :param headers: optional headers for the request
         :return: obtained response
         """
         try:
-            result = await self.loop_request(self.services[service] + args, method, data)
+            result = await self.loop_request(self.services[service] + args, method, data, headers)
             return result
         except TypeError:
             logger.error(TypeError(f'Incorrect argument {args} for service {service}.'))
 
-    async def loop_request(self, url, method, data, depth=10):
+    async def loop_request(self, url, method, data, headers, depth=10):
         """
         Execute request with type depending on specified method.
 
@@ -45,20 +46,23 @@ class Converter:
         :param method: GET/POST
         :param data: given arguments for POST request
         :param depth: allowed recursion depth for unsuccessful requests
+        :param headers: optional headers for the request
         :return: obtained response
         """
+        if headers is None:
+            headers = dict()
         try:
             if method == 'GET':
-                async with self.session.get(url) as response:
+                async with self.session.get(url, headers=headers) as response:
                     return await self.process_request(response, url, method, data, depth)
             else:
-                async with self.session.post(url, data=data) as response:
+                async with self.session.post(url, data=data, headers=headers) as response:
                     return await self.process_request(response, url, method, data, depth)
         except (ServerDisconnectedError, aiohttp.client_exceptions.ClientConnectorError):
             if depth > 0:
                 logger.error(ServiceNotAvailable(f'Service {self.service_name} '
                                                  f'temporarily unavailable, trying again...'))
-                return await self.loop_request(url, method, data, depth - 1)
+                return await self.loop_request(url, method, data, headers, depth - 1)
             raise ServiceNotAvailable
 
     async def process_request(self, response, url, method, data, depth):
@@ -75,12 +79,6 @@ class Converter:
         result = await response.text()
         if response.ok:
             return result
-        elif response.status == 503:
-            # server busy, try again
-            if depth > 0:
-                logger.error(ServiceNotAvailable(f'Service {self.service_name} '
-                                                 f'temporarily unavailable, trying again...'))
-                return await self.loop_request(url, method, data, depth - 1)
         else:
             raise UnknownResponse(f'Unknown response {response.status}:{result} for {method} request on {url}.')
 

--- a/libs/services/PubChem.py
+++ b/libs/services/PubChem.py
@@ -1,5 +1,3 @@
-import json
-
 from libs.services.Converter import Converter
 from frozendict import frozendict
 
@@ -8,49 +6,108 @@ class PubChem(Converter):
     def __init__(self, session):
         super().__init__(session)
         # service URLs
-        self.services = {'PubChem': 'https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/'}
+        self.services = {'PubChem': 'https://idsm.elixir-czech.cz/sparql/endpoint/idsm'}
+        self.header = frozendict({"Accept": "application/sparql-results+json"})
 
-        self.attributes = [{'code': 'inchi', 'label': 'InChI', 'extra': None},
-                           {'code': 'inchikey', 'label': 'InChIKey', 'extra': None},
-                           {'code': 'iupac_name', 'label': 'IUPAC Name', 'extra': 'Preferred'},
-                           {'code': 'formula', 'label': 'Molecular Formula', 'extra': None},
-                           {'code': 'smiles', 'label': 'SMILES', 'extra': 'Canonical'}]
+        self.attributes = [{'code': 'inchi', 'label': 'CHEMINF_000396'},
+                           {'code': 'iupac_name', 'label': 'CHEMINF_000382'},
+                           {'code': 'inchikey', 'label': 'CHEMINF_000399'},
+                           {'code': 'formula', 'label': 'CHEMINF_000335'},
+                           {'code': 'smiles', 'label': 'CHEMINF_000376'}]
 
         # generate top level methods defining allowed conversions
         conversions = [('name', 'inchi', 'from_name'),
-                       ('name', 'inchikey', 'from_name'),
                        ('name', 'iupac_name', 'from_name'),
                        ('name', 'formula', 'from_name'),
                        ('name', 'smiles', 'from_name'),
-                       ('inchi', 'inchikey', 'from_inchi'),
                        ('inchi', 'iupac_name', 'from_inchi'),
                        ('inchi', 'formula', 'from_inchi'),
                        ('inchi', 'smiles', 'from_inchi')]
         self.create_top_level_conversion_methods(conversions)
 
-    async def from_name(self, name):
+    async def name_to_inchikey(self, name):
         """
-        Convert Chemical name to all possible attributes using PubChem service
-        More info: https://pubchemdocs.ncbi.nlm.nih.gov/pug-rest
+        Convert Chemical name to InChIKey using IDSM service
 
         :param name: given Chemical name
         :return: all found data
         """
-        args = f'name/{name}/JSON'
-        response = await self.query_the_service('PubChem', args)
-        if response:
-            return self.parse_attributes(response)
-
-    async def from_inchi(self, inchi):
+        query = f"""
+        SELECT DISTINCT ?type ?value
+        WHERE
+        {{
+          ?inchikey sio:has-value ?value.
+          ?inchikey rdf:type ?type.
+          ?inchikey sio:is-attribute-of ?compound.
+          ?synonym sio:is-attribute-of ?compound.
+          ?synonym sio:has-value "{name.lower()}"@en.
+        }}
         """
-        Convert InChi to to all possible attributes using PubChem service
-        More info: https://pubchemdocs.ncbi.nlm.nih.gov/pug-rest
+        return await self.call_service(query)
+
+    async def inchi_to_inchikey(self, inchi):
+        """
+        Convert InChi to InChIKey using IDSM service
 
         :param inchi: given InChi
         :return: all found data
         """
-        args = "inchi/JSON"
-        response = await self.query_the_service('PubChem', args, method='POST', data=frozendict({'inchi': inchi}))
+        query = f"""
+        SELECT DISTINCT ?type ?value
+        WHERE
+        {{
+          ?inchikey sio:has-value ?value.
+          ?inchikey rdf:type ?type.
+          ?inchikey sio:is-attribute-of ?compound.
+          ?compound sio:has-attribute ?inchi.
+          ?inchi sio:has-value "{inchi}"@en.
+        }}
+        """
+        return await self.call_service(query)
+
+    async def from_name(self, name):
+        """
+        Convert Chemical name to all possible attributes using IDSM service
+
+        :param name: given Chemical name
+        :return: all found data
+        """
+        query = f"""
+        SELECT DISTINCT ?value ?type
+        WHERE
+        {{
+          ?attribute rdf:type ?type.
+          ?attribute sio:has-value ?value.
+          ?compound sio:has-attribute ?attribute.
+          ?synonym sio:is-attribute-of ?compound.
+          ?synonym sio:has-value "{name.lower()}"@en.
+        }}
+        """
+        return await self.call_service(query)
+
+    async def from_inchi(self, inchi):
+        """
+        Convert InChi to to all possible attributes using IDSM service
+
+        :param inchi: given InChi
+        :return: all found data
+        """
+        query = f"""
+        SELECT DISTINCT ?value ?type
+        WHERE
+        {{
+          ?attribute rdf:type ?type.
+          ?attribute sio:has-value ?value.
+          ?compound sio:has-attribute ?attribute.
+          ?compound sio:has-attribute ?inchi.
+          ?inchi sio:has-value "{inchi}"@en.
+        }}
+        """
+        return await self.call_service(query)
+
+    async def call_service(self, query):
+        data = frozendict({"query": query})
+        response = await self.query_the_service('PubChem', '', method='POST', data=data, headers=self.header)
         if response:
             return self.parse_attributes(response)
 
@@ -63,16 +120,13 @@ class PubChem(Converter):
         :param response: given JSON
         :return: all parsed data
         """
-        response_json = json.loads(response)
+        response_json = eval(response)
         result = dict()
 
-        for prop in response_json['PC_Compounds'][0]['props']:
-            label = prop['urn']['label']
+        for prop in response_json['results']['bindings']:
+            identifier = prop['type']['value'].rsplit('/', 1)[-1]
+            value = prop['value']['value']
             for att in self.attributes:
-                if label == att['label']:
-                    if att['extra']:
-                        if prop['urn']['name'] == att['extra']:
-                            result[att['code']] = prop['value']['sval']
-                    else:
-                        result[att['code']] = prop['value']['sval']
+                if identifier == att['label']:
+                    result[att['code']] = value
         return result


### PR DESCRIPTION
Replaced usage of [PubChem API service](https://pubchemdocs.ncbi.nlm.nih.gov/pug-rest) by a more robust [IDSM SPARQL](https://idsm.elixir-czech.cz/sparql) alternative. This should significantly improve the performance and make real deployment (#11) possible, but this needs to be tested.

This also required to limit the frequency of requests for this service using [Semaphore](https://docs.python.org/3/library/asyncio-sync.html#semaphore). Other used services do not specify any limitations. Close #16.