### PR TITLE
44 Check service status in tests

### DIFF
--- a/conda/environment-dev.yml
+++ b/conda/environment-dev.yml
@@ -17,3 +17,4 @@ dependencies:
   - pytest
   - pytest-aiohttp
   - pytest-cov
+  - pytest-dependency

--- a/tests/test_CIR.py
+++ b/tests/test_CIR.py
@@ -6,6 +6,12 @@ from pyMSPannotator.libs.utils.Errors import UnknownResponse
 from tests.utils import wrap_with_session
 
 
+@pytest.mark.dependency()
+def test_service_available():
+    asyncio.run(wrap_with_session(CIR, 'casno_to_smiles', ['7783-89-3']))
+
+
+@pytest.mark.dependency(depends=["test_service_available"])
 @pytest.mark.parametrize('arg, value, expected, method', [
     ['smiles', '7783-89-3', '[Ag+].[O-][Br](=O)=O', 'casno_to_smiles'],
     ['smiles', 'XQLMNMQWVCXIKR-UHFFFAOYSA-M', '[Ag+].[O-][Br](=O)=O', 'inchikey_to_smiles'],
@@ -18,6 +24,7 @@ def test_correct_behavior(arg, value, expected, method):
     assert asyncio.run(wrap_with_session(CIR, method, [value]))[arg] == expected
 
 
+@pytest.mark.dependency(depends=["test_service_available"])
 @pytest.mark.parametrize('arg, value, method', [
     ['smiles', '7783893', 'casno_to_smiles'],
     ['smiles', 'XQLMNVCXIKR-UHFFFAOYSA-M', 'inchikey_to_smiles'],

--- a/tests/test_CTS.py
+++ b/tests/test_CTS.py
@@ -7,6 +7,12 @@ from pyMSPannotator.libs.utils.Errors import UnknownResponse
 from tests.utils import wrap_with_session
 
 
+@pytest.mark.dependency()
+def test_service_available():
+    asyncio.run(wrap_with_session(CTS, 'casno_to_inchikey', ['7783-89-3']))
+
+
+@pytest.mark.dependency(depends=["test_service_available"])
 @pytest.mark.parametrize('arg, value, expected, method', [
     ['inchikey', '7783-89-3', 'XQLMNMQWVCXIKR-UHFFFAOYSA-M', 'casno_to_inchikey'],
     ['inchi', 'XQLMNMQWVCXIKR-UHFFFAOYSA-M', 'InChI=1S/Ag.BrHO3/c;2-1(3)4/h;(H,2,3,4)/q+1;/p-1', 'inchikey_to_inchi'],
@@ -18,6 +24,7 @@ def test_correct_behavior(arg, value, expected, method):
     assert asyncio.run(wrap_with_session(CTS, method, [value]))[arg] == expected
 
 
+@pytest.mark.dependency(depends=["test_service_available"])
 @pytest.mark.parametrize('arg, value, method', [
     ['inchi', 'XQLMNMQIKR-UHFFFAOYSA-M', 'inchikey_to_inchi'],
     ['name', 'XQLMNMQIKR-UHFFFAOYSA-M', 'inchikey_to_name'],
@@ -28,6 +35,7 @@ def test_incorrect_behavior_exception(arg, value, method):
         asyncio.run(wrap_with_session(CTS, method, [value]))
 
 
+@pytest.mark.dependency(depends=["test_service_available"])
 @pytest.mark.parametrize('arg, value, method', [
     ['inchikey', '7783893', 'casno_to_inchikey'],
     ['inchikey', 'L-Alalalalanine', 'name_to_inchikey']
@@ -36,6 +44,7 @@ def test_incorrect_behavior_none(arg, value, method):
     assert asyncio.run(wrap_with_session(CTS, method, [value])) is None
 
 
+@pytest.mark.dependency(depends=["test_service_available"])
 @pytest.mark.parametrize('value, size', [
     ['7783-89-3', 1],
     ['7783893', 0]

--- a/tests/test_NLM.py
+++ b/tests/test_NLM.py
@@ -8,6 +8,12 @@ from pyMSPannotator.libs.utils.Errors import UnknownResponse
 from tests.utils import wrap_with_session
 
 
+@pytest.mark.dependency()
+def test_service_available():
+    asyncio.run(wrap_with_session(NLM, 'inchikey_to_name', ['QNAYBMKLOCPYGJ-REOHCLBHSA-N']))
+
+
+@pytest.mark.dependency(depends=["test_service_available"])
 @pytest.mark.parametrize('arg, value, expected, method', [
     ['name', 'QNAYBMKLOCPYGJ-REOHCLBHSA-N', 'Alanine [USAN:INN]', 'inchikey_to_name'],
     ['inchikey', 'L-Alanine', 'QNAYBMKLOCPYGJ-REOHCLBHSA-N', 'name_to_inchikey'],
@@ -20,6 +26,7 @@ def test_correct_behavior(arg, value, expected, method):
     assert asyncio.run(wrap_with_session(NLM, method, [value]))[arg] == expected
 
 
+@pytest.mark.dependency(depends=["test_service_available"])
 @pytest.mark.parametrize('arg, value, method', [
     ['name', 'QNAYBMLOXXXXGJ-REOHCLBHSA-N', 'inchikey_to_name'],
     ['inchikey', 'L-Alanne', 'name_to_inchikey'],
@@ -31,6 +38,7 @@ def test_incorrect_behavior_exception(arg, value, method):
         asyncio.run(wrap_with_session(NLM, method, [value]))
 
 
+@pytest.mark.dependency(depends=["test_service_available"])
 @pytest.mark.parametrize('arg, value, method', [
     ['name', 'QNAYMLGJ-REOLBHSA-N', 'inchikey_to_name'],
     ['formula', 'QNAYMLGJ-REOLBHSA-N', 'inchikey_to_formula'],
@@ -40,6 +48,7 @@ def test_incorrect_behavior_none(arg, value, method):
     assert asyncio.run(wrap_with_session(NLM, method, [value])) is None
 
 
+@pytest.mark.dependency(depends=["test_service_available"])
 def test_format():
     inchikey = 'QNAYBMKLOCPYGJ-REOHCLBHSA-N'
     args = 'inchikey/equals/{}?data=summary&format=tsv'.format(inchikey)

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -6,7 +6,6 @@ import pytest
 from aiohttp import ServerDisconnectedError
 from aiohttp import web
 
-from pyMSPannotator.libs.services import CTS, CIR
 from pyMSPannotator.libs.services.Converter import Converter
 from pyMSPannotator.libs.utils.Errors import TargetAttributeNotRetrieved, UnknownResponse
 
@@ -114,6 +113,16 @@ def test_convert():
         _ = asyncio.run(converter.convert('B', 'C', None))
 
 
+@pytest.mark.dependency()
+def test_services_available():
+    from tests.utils import wrap_with_session
+    from pyMSPannotator.libs.services import CTS, CIR
+
+    asyncio.run(wrap_with_session(CTS, 'casno_to_inchikey', ['7783-89-3']))
+    asyncio.run(wrap_with_session(CIR, 'casno_to_smiles', ['7783-89-3']))
+
+
+@pytest.mark.dependency(depends=["test_services_available"])
 @pytest.mark.parametrize('service, args', [
     ['CTS', 'CAS/InChIKey/7783-89-3'],
     ['CTS', 'CAS/InChIKey/7783893'],

--- a/tests/test_pubchem.py
+++ b/tests/test_pubchem.py
@@ -11,6 +11,12 @@ INCHI = 'InChI=1S/C11H8FNO3/c1-13-6-9(10(14)16-11(13)15)7-2-4-8(12)5-3-7/h2-6H,1
 WRONG_INCHI = 'InChI=1S/C9H10O4/c102-4-7)5-8(11)93/1-4,8,10-11H,5H2,(H,12,13)'
 
 
+@pytest.mark.dependency()
+def test_service_available():
+    asyncio.run(wrap_with_session(PubChem, 'inchi_to_inchikey', [INCHI]))
+
+
+@pytest.mark.dependency(depends=["test_service_available"])
 @pytest.mark.parametrize('arg, value, expected, method', [
     ['inchikey', INCHI, 'DHVXXNFWDPJSOI-UHFFFAOYSA-N', 'inchi_to_inchikey'],
     ['inchi', '3-Methyl-5-[p-fluorophenyl]-2H-1,3-[3H]-oxazine-2,6-dione', INCHI, 'name_to_inchi'],
@@ -22,6 +28,7 @@ def test_correct_behavior(arg, value, expected, method):
     assert asyncio.run(wrap_with_session(PubChem, method, [value]))[arg] == expected
 
 
+@pytest.mark.dependency(depends=["test_service_available"])
 @pytest.mark.parametrize('arg, value, method', [
     ['inchikey', WRONG_INCHI, 'inchi_to_inchikey'],
     ['inchi', 'L-Alanne', 'name_to_inchi'],
@@ -33,6 +40,7 @@ def test_incorrect_behavior(arg, value, method):
     assert len(asyncio.run(wrap_with_session(PubChem, method, [value]))) == 0
 
 
+@pytest.mark.dependency(depends=["test_service_available"])
 def test_format():
     inchi = 'InChI=1S/C9H10O4/c10-7-3-1-6(2-4-7)5-8(11)9(12)13/h1-4,8,10-11H,5H2,(H,12,13)'
 


### PR DESCRIPTION
Wrapped tests using a service to `pytest-dependency` which checks if the service is running. This way, other tests do not fail when the service is not available, but are skipped instead. Close #44.